### PR TITLE
Feature: add internal endpoint for profile import

### DIFF
--- a/httpRequests/internal-profile-upsert.http
+++ b/httpRequests/internal-profile-upsert.http
@@ -72,7 +72,7 @@ Content-Type: application/json
   }
 }
 
-### 7. Отсутсвуют детали (400)
+### 7. Список деталей пустой (400)
 PATCH http://localhost:8089/api/profile/internal/profile
 Content-Type: application/json
 
@@ -83,7 +83,15 @@ Content-Type: application/json
   }
 }
 
-### 8. Ошибки валидации: невалидное значение поля (400)
+### 8. Отсутсвуют детали (400)
+PATCH http://localhost:8089/api/profile/internal/profile
+Content-Type: application/json
+
+{
+  "telegram_user_id": 100
+}
+
+### 9. Ошибки валидации: невалидное значение поля (400)
 PATCH http://localhost:8089/api/profile/internal/profile
 Content-Type: application/json
 

--- a/httpRequests/internal-profile-upsert.http
+++ b/httpRequests/internal-profile-upsert.http
@@ -1,0 +1,96 @@
+### 1. Успешное создание профиля пользователя (201 Created)
+# profile с telegram_user_id = 1201 не должен существовать в БД
+PATCH http://localhost:8089/api/profile/internal/profile
+Content-Type: application/json
+
+{
+  "telegram_user_id": 1201,
+  "details": {
+    "github_profile_url": "https://github.com/created_by_internal_request",
+    "telegram_url": "https://t.me/created_by_internal_request"
+  }
+}
+
+### 2. Успешное обновление профиля существующего пользователя (200 OK)
+# В БД должен существовать profile с telegram_user_id = 1201
+PATCH http://localhost:8089 /api/profile/internal/profile
+Content-Type: application/json
+
+{
+  "telegram_user_id": 1201,
+  "details": {
+    "github_profile_url": "https://github.com/updated_by_internal_request",
+    "telegram_url": "https://t.me/updated_by_internal_request"
+  }
+}
+
+### 3. Успешное обновление одного параметра профиля без затирания другого (200 OK)
+# В БД должен существовать profile с telegram_user_id = 1201
+# Проверить в БД что другой параметр не изменился
+PATCH http://localhost:8089 /api/profile/internal/profile
+Content-Type: application/json
+
+{
+  "telegram_user_id": 1201,
+  "details": {
+    "github_profile_url": "https://github.com/updated_ONLY_THIS_without_another"
+  }
+}
+
+### 4. Ошибки валидации: невалидные поля (400)
+PATCH http://localhost:8089/api/profile/internal/profile
+Content-Type: application/json
+
+{
+  "telegram_user_id": 100,
+  "details": {
+    "not_valid_detail_name": "https://github.com/not_valid_detail_name",
+    "telegram_url": "https://t.me/not_valid_detail_name"
+  }
+}
+
+### 5. Отсутсвует telegram_user_id (400)
+PATCH http://localhost:8089/api/profile/internal/profile
+Content-Type: application/json
+
+{
+  "details": {
+    "github_profile_url": "https://github.com/test4",
+    "telegram_url": "https://t.me/test4"
+  }
+}
+
+### 6. Невалидный telegram_user_id (400)
+PATCH http://localhost:8089/api/profile/internal/profile
+Content-Type: application/json
+
+{
+  "telegram_user_id": "not valid",
+  "details": {
+    "github_profile_url": "https://github.com/test4",
+    "telegram_url": "https://t.me/test4"
+  }
+}
+
+### 7. Отсутсвуют детали (400)
+PATCH http://localhost:8089/api/profile/internal/profile
+Content-Type: application/json
+
+{
+  "telegram_user_id": 100,
+  "details": {
+
+  }
+}
+
+### 8. Ошибки валидации: невалидное значение поля (400)
+PATCH http://localhost:8089/api/profile/internal/profile
+Content-Type: application/json
+
+{
+  "telegram_user_id": 100,
+  "details": {
+    "github_profile_url": "not valid",
+    "telegram_url": "https://t.me/user100"
+  }
+}

--- a/httpRequests/requests.http
+++ b/httpRequests/requests.http
@@ -3,8 +3,8 @@
 # INSERT INTO profiles(telegram_user_id) VALUES(1);
 # INSERT INTO profiles_details(profile_id, detail_name, detail_value)
 # VALUES
-# (1, 'github_profile', 'https://github.com/testuser'),
-# (1, 'telegram_username', '@testuser');
+# (1, 'github_profile_url', 'https://github.com/testuser'),
+# (1, 'telegram_url', 'https://t.me/testuser');
 
 GET http://localhost:8088/api/profile
 X-Telegram-User-Id: 1

--- a/src/main/java/com/itmentorcommunityplatform/profileservice/controller/InternalProfileController.java
+++ b/src/main/java/com/itmentorcommunityplatform/profileservice/controller/InternalProfileController.java
@@ -1,5 +1,6 @@
 package com.itmentorcommunityplatform.profileservice.controller;
 
+import com.itmentorcommunityplatform.profileservice.docs.UpsertInternalProfileDocs;
 import com.itmentorcommunityplatform.profileservice.dto.request.ProfileUpsertInternalRequestDto;
 import com.itmentorcommunityplatform.profileservice.service.ProfileService;
 import lombok.RequiredArgsConstructor;
@@ -18,6 +19,7 @@ public class InternalProfileController {
     private final ProfileService profileService;
 
     @PatchMapping("/profile")
+    @UpsertInternalProfileDocs
     public ResponseEntity<Void> upsertProfile(
             @RequestBody ProfileUpsertInternalRequestDto dto){
         boolean isCreated = profileService.upsertProfile(dto);

--- a/src/main/java/com/itmentorcommunityplatform/profileservice/controller/InternalProfileController.java
+++ b/src/main/java/com/itmentorcommunityplatform/profileservice/controller/InternalProfileController.java
@@ -1,0 +1,28 @@
+package com.itmentorcommunityplatform.profileservice.controller;
+
+import com.itmentorcommunityplatform.profileservice.dto.request.ProfileUpsertInternalRequestDto;
+import com.itmentorcommunityplatform.profileservice.service.ProfileService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/profile/internal")
+@RequiredArgsConstructor
+public class InternalProfileController {
+
+    private final ProfileService profileService;
+
+    @PatchMapping("/profile")
+    public ResponseEntity<Void> upsertProfile(
+            @RequestBody ProfileUpsertInternalRequestDto dto){
+        boolean isCreated = profileService.upsertProfile(dto);
+        return isCreated
+                ? ResponseEntity.status(HttpStatus.CREATED).build()
+                : ResponseEntity.ok().build();
+    }
+}

--- a/src/main/java/com/itmentorcommunityplatform/profileservice/docs/UpsertInternalProfileDocs.java
+++ b/src/main/java/com/itmentorcommunityplatform/profileservice/docs/UpsertInternalProfileDocs.java
@@ -1,0 +1,75 @@
+package com.itmentorcommunityplatform.profileservice.docs;
+
+import com.itmentorcommunityplatform.profileservice.dto.request.ProfileUpsertInternalRequestDto;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.parameters.RequestBody;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+@Operation(
+        summary = "Upsert user profile (internal)",
+        description = """
+                Create or update a user's profile details.
+                It is used by internal services.
+                Requires `telegram_user_id` and any set of details.
+
+                ### Example request body
+                ```json
+                {
+                  "telegram_user_id": 12345,
+                  "details": {
+                    "github_profile_url": "https://github.com/johndoe",
+                    "telegram_url": "https://t.me/johndoe"
+                  }
+                }
+                ```
+                """,
+        requestBody = @RequestBody(
+                required = true,
+                content = @Content(
+                        mediaType = "application/json",
+                        schema = @Schema(implementation = ProfileUpsertInternalRequestDto.class),
+                        examples = @ExampleObject(
+                                name = "Internal profile upsert example",
+                                value = """
+                                        {
+                                          "telegram_user_id": 12345,
+                                          "details": {
+                                            "github_profile_url": "https://github.com/johndoe",
+                                            "telegram_url": "https://t.me/johndoe"
+                                          }
+                                        }
+                                        """
+                        )
+                )
+        )
+)
+@ApiResponses({
+        @ApiResponse(
+                responseCode = "201",
+                description = "Profile created successfully"
+        ),
+        @ApiResponse(
+                responseCode = "200",
+                description = "Profile updated successfully"
+        ),
+        @ApiResponse(
+                responseCode = "400",
+                description = "Invalid request",
+                content = @Content(schema = @Schema(
+                        example = "{\"message\":\"Bad request\"}"
+                ))
+        )
+})
+public @interface UpsertInternalProfileDocs {
+}

--- a/src/main/java/com/itmentorcommunityplatform/profileservice/domain/type/ProfileDetailType.java
+++ b/src/main/java/com/itmentorcommunityplatform/profileservice/domain/type/ProfileDetailType.java
@@ -5,6 +5,20 @@ import lombok.Getter;
 import java.util.Arrays;
 import java.util.Optional;
 
+/**
+ * <p> Перечисление всех разрешённых параметров профиля (details),
+ * которые могут быть сохранены в системе. </p>
+ * detailName совпадает с ключом во входящем JSON.
+ * <p> Для добавления нового параметра профиля <br>
+ *   - добавьте новый элемент enum с уникальным detailName <br>
+ *   - при необходимости создайте валидатор имплементирующий
+ *      интерфейс ProfileDetailValidator и являющийся @Component
+ * </p>
+ * Пример:
+ *   GITHUB_PROFILE_URL("github_profile_url")
+ * <p> Статический метод fromName() позволяет получить тип по его
+ * detailName.</p>
+ */
 @Getter
 public enum ProfileDetailType {
 
@@ -18,6 +32,9 @@ public enum ProfileDetailType {
         this.detailName = detailName;
     }
 
+    /**
+     * Возвращает Optional с соответствующим ProfileDetailType по его строковому detailName.
+     */
     public static Optional<ProfileDetailType> fromName(String searchingName) {
         return Arrays.stream(values())
                 .filter(type -> type.detailName.equals(searchingName))

--- a/src/main/java/com/itmentorcommunityplatform/profileservice/domain/type/ProfileDetailType.java
+++ b/src/main/java/com/itmentorcommunityplatform/profileservice/domain/type/ProfileDetailType.java
@@ -1,0 +1,26 @@
+package com.itmentorcommunityplatform.profileservice.domain.type;
+
+import lombok.Getter;
+
+import java.util.Arrays;
+import java.util.Optional;
+
+@Getter
+public enum ProfileDetailType {
+
+    GITHUB_PROFILE_URL("github_profile_url"),
+
+    TELEGRAM_URL("telegram_url");
+
+    private final String detailName;
+
+    ProfileDetailType(String detailName) {
+        this.detailName = detailName;
+    }
+
+    public static Optional<ProfileDetailType> fromName(String searchingName) {
+        return Arrays.stream(values())
+                .filter(type -> type.detailName.equals(searchingName))
+                .findFirst();
+    }
+}

--- a/src/main/java/com/itmentorcommunityplatform/profileservice/dto/ProfileDto.java
+++ b/src/main/java/com/itmentorcommunityplatform/profileservice/dto/ProfileDto.java
@@ -1,16 +1,19 @@
 package com.itmentorcommunityplatform.profileservice.dto;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
-import lombok.Builder;
-import lombok.Data;
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
 
-@Data
-@Builder
+import java.util.Map;
+
 public class ProfileDto {
 
-    @JsonProperty("github_profile_url")
-    private String githubProfileUrl;
+    private final Map<String, String> details;
 
-    @JsonProperty("telegram_url")
-    private String telegramUrl;
+    public ProfileDto(Map<String, String> details) {
+        this.details = details;
+    }
+
+    @JsonAnyGetter
+    public Map<String, String> anyToJson() {
+        return details;
+    }
 }

--- a/src/main/java/com/itmentorcommunityplatform/profileservice/dto/ProfileDto.java
+++ b/src/main/java/com/itmentorcommunityplatform/profileservice/dto/ProfileDto.java
@@ -1,9 +1,22 @@
 package com.itmentorcommunityplatform.profileservice.dto;
 
 import com.fasterxml.jackson.annotation.JsonAnyGetter;
+import io.swagger.v3.oas.annotations.media.Schema;
 
 import java.util.Map;
 
+@Schema(
+        description = "User Profile Details - an arbitrary set of allowed fields",
+        additionalProperties = Schema.AdditionalPropertiesValue.TRUE,
+        example = """
+        {
+          "github_profile_url": "https://github.com/johndoe",
+          "telegram_url": "https://t.me/johndoe",
+          "twitter_handle": "@johndoe",
+          "full_name": "John Doe"
+        }
+        """
+)
 public class ProfileDto {
 
     private final Map<String, String> details;

--- a/src/main/java/com/itmentorcommunityplatform/profileservice/dto/request/ProfileUpdateRequestDto.java
+++ b/src/main/java/com/itmentorcommunityplatform/profileservice/dto/request/ProfileUpdateRequestDto.java
@@ -1,11 +1,22 @@
 package com.itmentorcommunityplatform.profileservice.dto.request;
 
 import com.fasterxml.jackson.annotation.JsonAnySetter;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Getter;
 
 import java.util.HashMap;
 import java.util.Map;
 
+@Schema(
+        description = "Profile Update Request - any set of allowed fields",
+        additionalProperties = Schema.AdditionalPropertiesValue.TRUE,
+        example = """
+        {
+          "github_profile_url": "https://github.com/johndoe",
+          "telegram_url": "https://t.me/johndoe"
+        }
+        """
+)
 @Getter
 public class ProfileUpdateRequestDto {
     private final Map<String, String> details = new HashMap<>();

--- a/src/main/java/com/itmentorcommunityplatform/profileservice/dto/request/ProfileUpdateRequestDto.java
+++ b/src/main/java/com/itmentorcommunityplatform/profileservice/dto/request/ProfileUpdateRequestDto.java
@@ -1,11 +1,17 @@
 package com.itmentorcommunityplatform.profileservice.dto.request;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonAnySetter;
+import lombok.Getter;
 
-public record ProfileUpdateRequestDto(
-        @JsonProperty("github_profile_url")
-        String githubProfileUrl,
-        @JsonProperty("telegram_url")
-        String telegramUrl
-) {
+import java.util.HashMap;
+import java.util.Map;
+
+@Getter
+public class ProfileUpdateRequestDto {
+    private final Map<String, String> details = new HashMap<>();
+
+    @JsonAnySetter
+    public void addDetail(String key, String value) {
+        details.put(key, value);
+    }
 }

--- a/src/main/java/com/itmentorcommunityplatform/profileservice/dto/request/ProfileUpsertInternalRequestDto.java
+++ b/src/main/java/com/itmentorcommunityplatform/profileservice/dto/request/ProfileUpsertInternalRequestDto.java
@@ -1,0 +1,27 @@
+package com.itmentorcommunityplatform.profileservice.dto.request;
+
+import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public record ProfileUpsertInternalRequestDto(
+
+        @JsonProperty("telegram_user_id")
+        Long telegramUserId,
+
+        @JsonProperty("details")
+        Details details
+) {
+    @Getter
+    public static class Details {
+        private final Map<String, String> map = new HashMap<>();
+
+        @JsonAnySetter
+        public void add(String key, String value) {
+            map.put(key, value);
+        }
+    }
+}

--- a/src/main/java/com/itmentorcommunityplatform/profileservice/dto/request/ProfileUpsertInternalRequestDto.java
+++ b/src/main/java/com/itmentorcommunityplatform/profileservice/dto/request/ProfileUpsertInternalRequestDto.java
@@ -2,6 +2,7 @@ package com.itmentorcommunityplatform.profileservice.dto.request;
 
 import com.fasterxml.jackson.annotation.JsonAnySetter;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Getter;
 
 import java.util.HashMap;
@@ -15,6 +16,17 @@ public record ProfileUpsertInternalRequestDto(
         @JsonProperty("details")
         Details details
 ) {
+    @Schema(
+            description = "Custom profile Details",
+            additionalProperties = Schema.AdditionalPropertiesValue.TRUE,
+            example = """
+        {
+          "github_profile_url": "https://github.com/johndoe",
+          "twitter_handle": "@johndoe",
+          "portfolio": "https://johndoe.dev"
+        }
+        """
+    )
     @Getter
     public static class Details {
         private final Map<String, String> map = new HashMap<>();

--- a/src/main/java/com/itmentorcommunityplatform/profileservice/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/itmentorcommunityplatform/profileservice/exception/GlobalExceptionHandler.java
@@ -1,7 +1,10 @@
 package com.itmentorcommunityplatform.profileservice.exception;
 
+import com.fasterxml.jackson.core.JsonParseException;
+import com.fasterxml.jackson.databind.exc.MismatchedInputException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.web.bind.MissingRequestHeaderException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
@@ -24,6 +27,22 @@ public class GlobalExceptionHandler {
         return ResponseEntity
                 .status(HttpStatus.UNAUTHORIZED)
                 .body(Map.of("message", "The required title is missing: " + ex.getHeaderName()));
+    }
+
+    @ExceptionHandler(HttpMessageNotReadableException.class)
+    public ResponseEntity<Map<String, Object>> handleJsonNotValidField(HttpMessageNotReadableException ex) {
+        Throwable cause = ex.getCause();
+        String message = switch (cause) {
+            case MismatchedInputException ignored -> "Invalid type for field";
+            case JsonParseException ignored -> "Malformed JSON";
+            default -> null;
+        };
+        if (message != null) {
+            return ResponseEntity
+                    .status(HttpStatus.BAD_REQUEST)
+                    .body(Map.of("message", message));
+        }
+        throw ex;
     }
 
     @ExceptionHandler(Exception.class)

--- a/src/main/java/com/itmentorcommunityplatform/profileservice/service/ProfileService.java
+++ b/src/main/java/com/itmentorcommunityplatform/profileservice/service/ProfileService.java
@@ -2,10 +2,14 @@ package com.itmentorcommunityplatform.profileservice.service;
 
 import com.itmentorcommunityplatform.profileservice.domain.Profile;
 import com.itmentorcommunityplatform.profileservice.domain.ProfileDetail;
+import com.itmentorcommunityplatform.profileservice.domain.type.ProfileDetailType;
 import com.itmentorcommunityplatform.profileservice.dto.ProfileDto;
 import com.itmentorcommunityplatform.profileservice.dto.request.ProfileUpdateRequestDto;
+import com.itmentorcommunityplatform.profileservice.dto.request.ProfileUpsertInternalRequestDto;
 import com.itmentorcommunityplatform.profileservice.metrics.ProfileMetrics;
 import com.itmentorcommunityplatform.profileservice.repository.ProfileRepository;
+import com.itmentorcommunityplatform.profileservice.validator.base.BaseProfileDetailValidator;
+import com.itmentorcommunityplatform.profileservice.validator.registry.ProfileDetailValidatorRegistry;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
@@ -13,9 +17,12 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.server.ResponseStatusException;
 
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 
 @Slf4j
 @Service
@@ -24,6 +31,8 @@ public class ProfileService {
 
     private final ProfileRepository profileRepository;
     private final ProfileMetrics profileMetrics;
+    private final BaseProfileDetailValidator baseDetailValidator;
+    private final ProfileDetailValidatorRegistry detailValidatorRegistry;
 
     private static final Pattern TELEGRAM_PATTERN = Pattern.compile("^https://t\\.me/[^\\s/]+$");
     private static final Pattern GITHUB_PATTERN = Pattern.compile("^https://github\\.com/[^\\s]+$");
@@ -123,5 +132,64 @@ public class ProfileService {
 
     private boolean validGithubUrl(String url) {
         return url != null && GITHUB_PATTERN.matcher(url).matches();
+    }
+
+    @Transactional
+    public boolean upsertProfile(ProfileUpsertInternalRequestDto dto) {
+
+        Map<String, String> newDetailsMap = dto.details().getMap();
+        validateDetails(newDetailsMap);
+
+        Optional<Profile> foundProfile = profileRepository.findByTelegramUserId(dto.telegramUserId());
+        boolean isNewProfile = foundProfile.isEmpty();
+
+        Set<ProfileDetail> existingDetails = foundProfile.map(Profile::getDetails).orElse(null);
+
+        Set<ProfileDetail> mergedDetails = mergeProfileDetails(existingDetails, newDetailsMap);
+
+        Profile profile = Profile.builder()
+                .id(foundProfile.map(Profile::getId).orElse(null))
+                .telegramUserId(dto.telegramUserId())
+                .details(mergedDetails)
+                .build();
+
+        profileRepository.save(profile);
+
+        return isNewProfile;
+    }
+
+    private static Set<ProfileDetail> mergeProfileDetails(
+            Set<ProfileDetail> existingDetails,
+            Map<String, String> newDetailsMap
+    ) {
+        Map<String, String> mergedMap = new HashMap<>();
+
+        if (existingDetails != null) {
+            existingDetails.forEach(d -> mergedMap.put(d.getDetailName(), d.getDetailValue()));
+        }
+
+        mergedMap.putAll(newDetailsMap);
+
+        return mergedMap.entrySet().stream()
+                .map(e -> new ProfileDetail(e.getKey(), e.getValue()))
+                .collect(Collectors.toSet());
+    }
+
+    private void validateDetails(Map<String, String> details) {
+        for (var entry : details.entrySet()) {
+            String detailName = entry.getKey();
+            String detailValue = entry.getValue();
+
+            ProfileDetailType type = ProfileDetailType.fromName(detailName)
+                    .orElseThrow(() -> new ResponseStatusException(
+                            HttpStatus.BAD_REQUEST,
+                            "Unknown detail name: " + detailName
+                    ));
+
+            baseDetailValidator.validate(detailName, detailValue);
+
+            detailValidatorRegistry.getSpecificValidator(type.getDetailName())
+                    .ifPresent(v -> v.validate(detailValue));
+        }
     }
 }

--- a/src/main/java/com/itmentorcommunityplatform/profileservice/service/ProfileService.java
+++ b/src/main/java/com/itmentorcommunityplatform/profileservice/service/ProfileService.java
@@ -17,10 +17,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.server.ResponseStatusException;
 
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Optional;
-import java.util.Set;
+import java.util.*;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
@@ -151,7 +148,7 @@ public class ProfileService {
         Optional<Profile> foundProfile = profileRepository.findByTelegramUserId(telegramUserId);
         boolean isNewProfile = foundProfile.isEmpty();
 
-        Set<ProfileDetail> existingDetails = foundProfile.map(Profile::getDetails).orElse(null);
+        Set<ProfileDetail> existingDetails = foundProfile.map(Profile::getDetails).orElse(Collections.emptySet());
 
         Set<ProfileDetail> mergedDetails = mergeProfileDetails(existingDetails, newDetailsMap);
 
@@ -172,9 +169,8 @@ public class ProfileService {
     ) {
         Map<String, String> mergedMap = new HashMap<>();
 
-        if (existingDetails != null) {
-            existingDetails.forEach(d -> mergedMap.put(d.getDetailName(), d.getDetailValue()));
-        }
+        existingDetails.forEach(detail ->
+                mergedMap.put(detail.getDetailName(), detail.getDetailValue()));
 
         mergedMap.putAll(newDetailsMap);
 

--- a/src/main/java/com/itmentorcommunityplatform/profileservice/service/ProfileService.java
+++ b/src/main/java/com/itmentorcommunityplatform/profileservice/service/ProfileService.java
@@ -137,10 +137,18 @@ public class ProfileService {
     @Transactional
     public boolean upsertProfile(ProfileUpsertInternalRequestDto dto) {
 
+        Long telegramUserId = dto.telegramUserId();
+        if (telegramUserId == null) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "'telegram_user_id' must be provided");
+        }
+
+        if (dto.details() == null) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "'details' must be provided");
+        }
         Map<String, String> newDetailsMap = dto.details().getMap();
         validateDetails(newDetailsMap);
 
-        Optional<Profile> foundProfile = profileRepository.findByTelegramUserId(dto.telegramUserId());
+        Optional<Profile> foundProfile = profileRepository.findByTelegramUserId(telegramUserId);
         boolean isNewProfile = foundProfile.isEmpty();
 
         Set<ProfileDetail> existingDetails = foundProfile.map(Profile::getDetails).orElse(null);
@@ -149,7 +157,7 @@ public class ProfileService {
 
         Profile profile = Profile.builder()
                 .id(foundProfile.map(Profile::getId).orElse(null))
-                .telegramUserId(dto.telegramUserId())
+                .telegramUserId(telegramUserId)
                 .details(mergedDetails)
                 .build();
 
@@ -176,6 +184,9 @@ public class ProfileService {
     }
 
     private void validateDetails(Map<String, String> details) {
+        if (details == null || details.isEmpty()) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Profile details should not be empty");
+        }
         for (var entry : details.entrySet()) {
             String detailName = entry.getKey();
             String detailValue = entry.getValue();

--- a/src/main/java/com/itmentorcommunityplatform/profileservice/service/ProfileService.java
+++ b/src/main/java/com/itmentorcommunityplatform/profileservice/service/ProfileService.java
@@ -139,7 +139,7 @@ public class ProfileService {
 
             baseDetailValidator.validate(detailName, detailValue);
 
-            detailValidatorRegistry.getSpecificValidator(type.getDetailName())
+            detailValidatorRegistry.getSpecificValidator(type)
                     .ifPresent(v -> v.validate(detailValue));
         }
     }

--- a/src/main/java/com/itmentorcommunityplatform/profileservice/service/ProfileService.java
+++ b/src/main/java/com/itmentorcommunityplatform/profileservice/service/ProfileService.java
@@ -18,7 +18,6 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.server.ResponseStatusException;
 
 import java.util.*;
-import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 @Slf4j
@@ -30,9 +29,6 @@ public class ProfileService {
     private final ProfileMetrics profileMetrics;
     private final BaseProfileDetailValidator baseDetailValidator;
     private final ProfileDetailValidatorRegistry detailValidatorRegistry;
-
-    private static final Pattern TELEGRAM_PATTERN = Pattern.compile("^https://t\\.me/[^\\s/]+$");
-    private static final Pattern GITHUB_PATTERN = Pattern.compile("^https://github\\.com/[^\\s]+$");
 
     public ProfileDto getCurrentUserProfile(Long telegramUserId) {
         return profileMetrics.getGetProfileTimer().record(() -> {
@@ -53,25 +49,15 @@ public class ProfileService {
     public ProfileDto updateCurrentProfile(Long telegramUserId, ProfileUpdateRequestDto dto) {
         return profileMetrics.getGetProfileTimer().record(() -> {
             try {
-                String githubUrl = dto.githubProfileUrl();
-                String telegramUrl = dto.telegramUrl();
-                if(githubUrl==null && telegramUrl==null){
-                    throw new ResponseStatusException(HttpStatus.BAD_REQUEST,"No parameters found to update");
-                }
+                Map<String, String> newDetailsMap = dto.getDetails();
+                validateDetails(newDetailsMap);
 
                 Profile profile = profileRepository.findByTelegramUserId(telegramUserId)
                         .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Profile not found"));
 
-                if (validGithubUrl(githubUrl)) {
-                    upsertDetail(profile,"github_profile",githubUrl);
-                }else if (githubUrl != null){
-                    throw new ResponseStatusException(HttpStatus.BAD_REQUEST,"Github profile url incorrect");
-                }
-                if (validTelegramUrl(telegramUrl)) {
-                    upsertDetail(profile, "telegram_username", telegramUrl);
-                }else if (telegramUrl != null){
-                    throw new ResponseStatusException(HttpStatus.BAD_REQUEST,"Telegram profile url incorrect");
-                }
+                Set<ProfileDetail> mergedDetails = mergeProfileDetails(profile.getDetails(), newDetailsMap);
+                profile.setDetails(mergedDetails);
+
                 profileRepository.save(profile);
                 profileMetrics.getGetProfileSuccessCounter().increment();
                 return mapToDto(profile.getDetails());
@@ -83,52 +69,10 @@ public class ProfileService {
     }
 
     private ProfileDto mapToDto(Set<ProfileDetail> details) {
-        String githubUrl = null;
-        String telegramUrl = null;
-        if (details != null) {
-            for (ProfileDetail detail : details) {
-                if ("github_profile".equals(detail.getDetailName())) {
-                    githubUrl = detail.getDetailValue();
-                }
-                if ("telegram_username".equals(detail.getDetailName())) {
-                    String username = detail.getDetailValue();
-                    if (username != null && !username.startsWith("https://t.me/")) {
-                        telegramUrl = "https://t.me/" + username.replace("@", "");
-                    }else {
-                        telegramUrl = username;
-                    }
-                }
-            }
-        }
-        return ProfileDto.builder()
-                .githubProfileUrl(githubUrl)
-                .telegramUrl(telegramUrl)
-                .build();
-    }
+        Map<String, String> map = details.stream()
+                .collect(Collectors.toMap(ProfileDetail::getDetailName, ProfileDetail::getDetailValue));
 
-    private void upsertDetail(Profile profile, String detailName, String detailValue) {
-        Optional<ProfileDetail> existing = profile.getDetails()
-                .stream()
-                .filter(d -> d.getDetailName().equals(detailName))
-                .findFirst();
-        if (existing.isPresent()) {
-            existing.get().setDetailValue(detailValue);
-        } else {
-            profile.getDetails().add(
-                    ProfileDetail.builder()
-                            .detailName(detailName)
-                            .detailValue(detailValue)
-                            .build()
-            );
-        }
-    }
-
-    private boolean validTelegramUrl(String url) {
-        return url != null && TELEGRAM_PATTERN.matcher(url).matches();
-    }
-
-    private boolean validGithubUrl(String url) {
-        return url != null && GITHUB_PATTERN.matcher(url).matches();
+        return new ProfileDto(map);
     }
 
     @Transactional

--- a/src/main/java/com/itmentorcommunityplatform/profileservice/validator/ProfileDetailValidator.java
+++ b/src/main/java/com/itmentorcommunityplatform/profileservice/validator/ProfileDetailValidator.java
@@ -1,0 +1,13 @@
+package com.itmentorcommunityplatform.profileservice.validator;
+
+public interface ProfileDetailValidator {
+    /**
+     * Возвращает detailName из ProfileDetailType, для которого этот валидатор предназначен.
+     */
+    String getProfileDetailTypeName();
+
+    /**
+     * Выполнить валидацию специфичную для конкретного ProfileDetailType.
+     */
+    void validate(String value);
+}

--- a/src/main/java/com/itmentorcommunityplatform/profileservice/validator/ProfileDetailValidator.java
+++ b/src/main/java/com/itmentorcommunityplatform/profileservice/validator/ProfileDetailValidator.java
@@ -1,5 +1,21 @@
 package com.itmentorcommunityplatform.profileservice.validator;
 
+/**
+ * <p> Интерфейс для реализации специфичных валидаторов
+ * для отдельных типов параметров профиля.</p>
+ *
+ * Каждый валидатор отвечает за строгую проверку одного конкретного
+ * ProfileDetailType.
+ * <p>
+ * Как создать новый валидатор: <br>
+ *  1. Добавить новый элемент в ProfileDetailType. <br>
+ *  2. Создать класс, реализующий ProfileDetailValidator. <br>
+ *  3. Вернуть тип через getProfileDetailTypeName()
+ *     (обычно: ProfileDetailType.XYZ.getDetailName()). <br>
+ *  4. Реализовать проверку в validate(). <br>
+ *  5. Отметить класс @Component, чтобы Spring автоматически зарегистрировал его.
+ *  </p>
+ */
 public interface ProfileDetailValidator {
     /**
      * Возвращает detailName из ProfileDetailType, для которого этот валидатор предназначен.

--- a/src/main/java/com/itmentorcommunityplatform/profileservice/validator/ProfileDetailValidator.java
+++ b/src/main/java/com/itmentorcommunityplatform/profileservice/validator/ProfileDetailValidator.java
@@ -1,5 +1,7 @@
 package com.itmentorcommunityplatform.profileservice.validator;
 
+import com.itmentorcommunityplatform.profileservice.domain.type.ProfileDetailType;
+
 /**
  * <p> Интерфейс для реализации специфичных валидаторов
  * для отдельных типов параметров профиля.</p>
@@ -10,17 +12,17 @@ package com.itmentorcommunityplatform.profileservice.validator;
  * Как создать новый валидатор: <br>
  *  1. Добавить новый элемент в ProfileDetailType. <br>
  *  2. Создать класс, реализующий ProfileDetailValidator. <br>
- *  3. Вернуть тип через getProfileDetailTypeName()
- *     (обычно: ProfileDetailType.XYZ.getDetailName()). <br>
+ *  3. Вернуть тип через getSupportedProfileDetailType()
+ *     (обычно: ProfileDetailType.XYZ). <br>
  *  4. Реализовать проверку в validate(). <br>
  *  5. Отметить класс @Component, чтобы Spring автоматически зарегистрировал его.
  *  </p>
  */
 public interface ProfileDetailValidator {
     /**
-     * Возвращает detailName из ProfileDetailType, для которого этот валидатор предназначен.
+     * Возвращает ProfileDetailType, для которого этот валидатор предназначен.
      */
-    String getProfileDetailTypeName();
+    ProfileDetailType getSupportedProfileDetailType();
 
     /**
      * Выполнить валидацию специфичную для конкретного ProfileDetailType.

--- a/src/main/java/com/itmentorcommunityplatform/profileservice/validator/base/BaseProfileDetailValidator.java
+++ b/src/main/java/com/itmentorcommunityplatform/profileservice/validator/base/BaseProfileDetailValidator.java
@@ -4,6 +4,15 @@ import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Component;
 import org.springframework.web.server.ResponseStatusException;
 
+/**
+ * <p>Базовый валидатор.</p>
+ *
+ * Основное назначение: <br>
+ *   - выполнение общих для всех detailName проверок
+ *     (например, ограничение максимальной длины строки).<br>
+ * Если требуется добавить общие проверки для всех details,
+ * их следует разместить здесь.
+ */
 @Component
 public class BaseProfileDetailValidator {
 

--- a/src/main/java/com/itmentorcommunityplatform/profileservice/validator/base/BaseProfileDetailValidator.java
+++ b/src/main/java/com/itmentorcommunityplatform/profileservice/validator/base/BaseProfileDetailValidator.java
@@ -1,0 +1,16 @@
+package com.itmentorcommunityplatform.profileservice.validator.base;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Component;
+import org.springframework.web.server.ResponseStatusException;
+
+@Component
+public class BaseProfileDetailValidator {
+
+    public void validate(String detailName, String value) {
+        if (value != null && value.length() > 255)
+            throw new ResponseStatusException(
+                    HttpStatus.BAD_REQUEST,
+                    "Value of '" + detailName + "' exceeds max length 255");
+    }
+}

--- a/src/main/java/com/itmentorcommunityplatform/profileservice/validator/impl/GithubProfileUrlValidator.java
+++ b/src/main/java/com/itmentorcommunityplatform/profileservice/validator/impl/GithubProfileUrlValidator.java
@@ -1,0 +1,28 @@
+package com.itmentorcommunityplatform.profileservice.validator.impl;
+
+import com.itmentorcommunityplatform.profileservice.validator.ProfileDetailValidator;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Component;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.util.regex.Pattern;
+
+import static com.itmentorcommunityplatform.profileservice.domain.type.ProfileDetailType.GITHUB_PROFILE_URL;
+
+@Component
+public class GithubProfileUrlValidator implements ProfileDetailValidator {
+
+    private static final Pattern GITHUB_PATTERN = Pattern.compile("^https://github\\.com/[^\\s]+$");
+
+    @Override
+    public String getProfileDetailTypeName() {
+        return GITHUB_PROFILE_URL.getDetailName();
+    }
+
+    @Override
+    public void validate(String value) {
+        if (value == null || !GITHUB_PATTERN.matcher(value).matches()) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Github profile url incorrect");
+        }
+    }
+}

--- a/src/main/java/com/itmentorcommunityplatform/profileservice/validator/impl/GithubProfileUrlValidator.java
+++ b/src/main/java/com/itmentorcommunityplatform/profileservice/validator/impl/GithubProfileUrlValidator.java
@@ -1,5 +1,6 @@
 package com.itmentorcommunityplatform.profileservice.validator.impl;
 
+import com.itmentorcommunityplatform.profileservice.domain.type.ProfileDetailType;
 import com.itmentorcommunityplatform.profileservice.validator.ProfileDetailValidator;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Component;
@@ -15,8 +16,8 @@ public class GithubProfileUrlValidator implements ProfileDetailValidator {
     private static final Pattern GITHUB_PATTERN = Pattern.compile("^https://github\\.com/[^\\s]+$");
 
     @Override
-    public String getProfileDetailTypeName() {
-        return GITHUB_PROFILE_URL.getDetailName();
+    public ProfileDetailType getSupportedProfileDetailType() {
+        return GITHUB_PROFILE_URL;
     }
 
     @Override

--- a/src/main/java/com/itmentorcommunityplatform/profileservice/validator/impl/TelegramUrlValidator.java
+++ b/src/main/java/com/itmentorcommunityplatform/profileservice/validator/impl/TelegramUrlValidator.java
@@ -1,5 +1,6 @@
 package com.itmentorcommunityplatform.profileservice.validator.impl;
 
+import com.itmentorcommunityplatform.profileservice.domain.type.ProfileDetailType;
 import com.itmentorcommunityplatform.profileservice.validator.ProfileDetailValidator;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Component;
@@ -15,8 +16,8 @@ public class TelegramUrlValidator implements ProfileDetailValidator {
     private static final Pattern TELEGRAM_PATTERN = Pattern.compile("^https://t\\.me/[^\\s/]+$");
 
     @Override
-    public String getProfileDetailTypeName() {
-        return TELEGRAM_URL.getDetailName();
+    public ProfileDetailType getSupportedProfileDetailType() {
+        return TELEGRAM_URL;
     }
 
     @Override

--- a/src/main/java/com/itmentorcommunityplatform/profileservice/validator/impl/TelegramUrlValidator.java
+++ b/src/main/java/com/itmentorcommunityplatform/profileservice/validator/impl/TelegramUrlValidator.java
@@ -1,0 +1,28 @@
+package com.itmentorcommunityplatform.profileservice.validator.impl;
+
+import com.itmentorcommunityplatform.profileservice.validator.ProfileDetailValidator;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Component;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.util.regex.Pattern;
+
+import static com.itmentorcommunityplatform.profileservice.domain.type.ProfileDetailType.TELEGRAM_URL;
+
+@Component
+public class TelegramUrlValidator implements ProfileDetailValidator {
+
+    private static final Pattern TELEGRAM_PATTERN = Pattern.compile("^https://t\\.me/[^\\s/]+$");
+
+    @Override
+    public String getProfileDetailTypeName() {
+        return TELEGRAM_URL.getDetailName();
+    }
+
+    @Override
+    public void validate(String value) {
+        if (value == null || !TELEGRAM_PATTERN.matcher(value).matches()) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Telegram profile url incorrect");
+        }
+    }
+}

--- a/src/main/java/com/itmentorcommunityplatform/profileservice/validator/registry/ProfileDetailValidatorRegistry.java
+++ b/src/main/java/com/itmentorcommunityplatform/profileservice/validator/registry/ProfileDetailValidatorRegistry.java
@@ -1,0 +1,24 @@
+package com.itmentorcommunityplatform.profileservice.validator.registry;
+
+import com.itmentorcommunityplatform.profileservice.validator.ProfileDetailValidator;
+import org.springframework.stereotype.Component;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+@Component
+public class ProfileDetailValidatorRegistry {
+    private final Map<String, ProfileDetailValidator> validatorsMap = new HashMap<>();
+
+    public ProfileDetailValidatorRegistry(List<ProfileDetailValidator> validators) {
+        for (ProfileDetailValidator v : validators) {
+            validatorsMap.put(v.getProfileDetailTypeName(), v);
+        }
+    }
+
+    public Optional<ProfileDetailValidator> getSpecificValidator(String detailName) {
+        return Optional.ofNullable(validatorsMap.get(detailName));
+    }
+}

--- a/src/main/java/com/itmentorcommunityplatform/profileservice/validator/registry/ProfileDetailValidatorRegistry.java
+++ b/src/main/java/com/itmentorcommunityplatform/profileservice/validator/registry/ProfileDetailValidatorRegistry.java
@@ -8,6 +8,23 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
+/**
+ * <p>Реестр всех специфичных валидаторов параметров профиля.</p>
+ *
+ * <p>Registry автоматически собирает все реализации ProfileDetailValidator,
+ * которые находятся в Spring-контексте (отмечены @Component),
+ * и сопоставляет их с detailName.</p>
+ *
+ * <p>Основное назначение: <br>
+ *  - быстро определить, существует ли специфичный валидатор для detailName; <br>
+ *  - предоставить валидатор сервисам, которые выполняют валидацию details.</p>
+ *
+ * <p>Добавление нового валидатора: <br>
+ *  1. Создать класс, реализующий ProfileDetailValidator. <br>
+ *  2. Вернуть корректный detailName в getProfileDetailTypeName(). <br>
+ *  3. Отметить класс @Component. <br>
+ *  4. Registry автоматически подхватит его.</p>
+ */
 @Component
 public class ProfileDetailValidatorRegistry {
     private final Map<String, ProfileDetailValidator> validatorsMap = new HashMap<>();
@@ -18,6 +35,10 @@ public class ProfileDetailValidatorRegistry {
         }
     }
 
+    /**
+     * Возвращает специфичный валидатор для указанного detailName,
+     * если он зарегистрирован.
+     */
     public Optional<ProfileDetailValidator> getSpecificValidator(String detailName) {
         return Optional.ofNullable(validatorsMap.get(detailName));
     }

--- a/src/main/java/com/itmentorcommunityplatform/profileservice/validator/registry/ProfileDetailValidatorRegistry.java
+++ b/src/main/java/com/itmentorcommunityplatform/profileservice/validator/registry/ProfileDetailValidatorRegistry.java
@@ -1,5 +1,6 @@
 package com.itmentorcommunityplatform.profileservice.validator.registry;
 
+import com.itmentorcommunityplatform.profileservice.domain.type.ProfileDetailType;
 import com.itmentorcommunityplatform.profileservice.validator.ProfileDetailValidator;
 import org.springframework.stereotype.Component;
 
@@ -13,33 +14,33 @@ import java.util.Optional;
  *
  * <p>Registry автоматически собирает все реализации ProfileDetailValidator,
  * которые находятся в Spring-контексте (отмечены @Component),
- * и сопоставляет их с detailName.</p>
+ * и сопоставляет их с конкретным ProfileDetailType.</p>
  *
  * <p>Основное назначение: <br>
- *  - быстро определить, существует ли специфичный валидатор для detailName; <br>
+ *  - быстро определить, существует ли специфичный валидатор для конкретного ProfileDetailType; <br>
  *  - предоставить валидатор сервисам, которые выполняют валидацию details.</p>
  *
  * <p>Добавление нового валидатора: <br>
  *  1. Создать класс, реализующий ProfileDetailValidator. <br>
- *  2. Вернуть корректный detailName в getProfileDetailTypeName(). <br>
+ *  2. Вернуть корректный ProfileDetailType в getSupportedProfileDetailType(). <br>
  *  3. Отметить класс @Component. <br>
  *  4. Registry автоматически подхватит его.</p>
  */
 @Component
 public class ProfileDetailValidatorRegistry {
-    private final Map<String, ProfileDetailValidator> validatorsMap = new HashMap<>();
+    private final Map<ProfileDetailType, ProfileDetailValidator> validatorsMap = new HashMap<>();
 
     public ProfileDetailValidatorRegistry(List<ProfileDetailValidator> validators) {
         for (ProfileDetailValidator v : validators) {
-            validatorsMap.put(v.getProfileDetailTypeName(), v);
+            validatorsMap.put(v.getSupportedProfileDetailType(), v);
         }
     }
 
     /**
-     * Возвращает специфичный валидатор для указанного detailName,
+     * Возвращает специфичный валидатор для указанного ProfileDetailType,
      * если он зарегистрирован.
      */
-    public Optional<ProfileDetailValidator> getSpecificValidator(String detailName) {
-        return Optional.ofNullable(validatorsMap.get(detailName));
+    public Optional<ProfileDetailValidator> getSpecificValidator(ProfileDetailType detailType) {
+        return Optional.ofNullable(validatorsMap.get(detailType));
     }
 }


### PR DESCRIPTION
- добавлен новый эндпоинт POST `/api/profile/internal/profile`, контроллер и метод сервиса для работы с ним
- добавлены ручные .http тесты для успешного и всех неуспешных сценариев
- добавлена swagger дока для нового эндпоинта

Так же сделал рефакторинг и реструкторизацию с целью сделать более централизованную и расширяемую архитектуру для работы с параметрами профиля (details), которые должны увеличиться в будущем. 
Решил добавить enum для хранения всех допустимых details  в одном месте ProfileDetailType, поскольку уже даже сейчас в dev ветке в dto и в сервисах разные названия, "магические ключи". 
Так же постарался сделать валидацию более универсальной.
Dto сделал универсальными, что бы принимать любой список и возвращать полный список details.(если будет нужно то при маппинге можно будет добавить изъятие из списка каких-то параметров думаю)

Расширяемость без изменения существующей логики.
Чтобы добавить новый параметр профиля, теперь достаточно:
  - добавить элемент в ProfileDetailType
  - при необходимости создать специфичный валидатор используя интерфейс

При этом код сервисов, контроллеров и репозиториев менять не требуется.

Краткое содержание изменений
1. Добавлен enum ProfileDetailType
  - централизует разрешённые detailName
  - позволяет проверять входящие параметры
  - выступает связующим звеном для валидаторов
2. Создан базовый валидатор BaseProfileDetailValidator
 - выполняет общие проверки независимо от конкретного параметра
3. Добавлен интерфейс ProfileDetailValidator
  - определяет контракт для специфичной валидации
  - через метод getSupportedProfileDetailType() валидатор привязывается к конкретному ProfileDetailType
4. Реализован ProfileDetailValidatorRegistry
  - автоматически собирает все валидаторы через Spring
  - обеспечивает быстрый поиск валидатора по ProfileDetailType
5. Обновлены DTO
  - теперь набор details получается и отдается динамически, вместо привязки в конкретным 
    значениям и необходимости редактировать dto при добавлении новых details
  - DTO автоматически собирают входящие details в Map, без хардкода ключей, далее проверяем 
    наличие ключей в enum который хранит все  detailName
6. Добавлены Javadoc-комментарии
  - описывают назначения классов
  - объясняют, как правильно расширять систему
  - упрощают понимание архитектуры для новых разработчиков