### PR TITLE
Добавлен Kafka consumer и автоматическое создание профиля пользователя

### DIFF
--- a/src/main/java/com/itmentorcommunityplatform/profileservice/config/KafkaConfig.java
+++ b/src/main/java/com/itmentorcommunityplatform/profileservice/config/KafkaConfig.java
@@ -1,0 +1,48 @@
+package com.itmentorcommunityplatform.profileservice.config;
+
+import com.itmentorcommunityplatform.profileservice.dto.event.UserCreatedEvent;
+import lombok.RequiredArgsConstructor;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.springframework.boot.autoconfigure.kafka.KafkaProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.annotation.EnableKafka;
+import org.springframework.kafka.config.ConcurrentKafkaListenerContainerFactory;
+import org.springframework.kafka.core.ConsumerFactory;
+import org.springframework.kafka.core.DefaultKafkaConsumerFactory;
+import org.springframework.kafka.listener.ContainerProperties;
+import org.springframework.kafka.support.serializer.ErrorHandlingDeserializer;
+import org.springframework.kafka.support.serializer.JsonDeserializer;
+
+import java.util.Map;
+
+@Configuration
+@EnableKafka
+@RequiredArgsConstructor
+public class KafkaConfig {
+
+    private final KafkaProperties kafkaProperties;
+
+    @Bean
+    public ConsumerFactory<String, UserCreatedEvent> consumerFactory() {
+        Map<String, Object> props = kafkaProperties.buildConsumerProperties(null);
+        props.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
+        props.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, ErrorHandlingDeserializer.class);
+        props.put(ErrorHandlingDeserializer.VALUE_DESERIALIZER_CLASS, JsonDeserializer.class.getName());
+        props.put(JsonDeserializer.TRUSTED_PACKAGES, "*");
+        props.put(JsonDeserializer.USE_TYPE_INFO_HEADERS, false);
+        props.put(JsonDeserializer.VALUE_DEFAULT_TYPE, UserCreatedEvent.class.getName());
+        return new DefaultKafkaConsumerFactory<>(props);
+    }
+
+    @Bean
+    public ConcurrentKafkaListenerContainerFactory<String, UserCreatedEvent> kafkaListenerContainerFactory() {
+        ConcurrentKafkaListenerContainerFactory<String, UserCreatedEvent> factory =
+                new ConcurrentKafkaListenerContainerFactory<>();
+        factory.setConsumerFactory(consumerFactory());
+        factory.getContainerProperties().setMissingTopicsFatal(true);
+        factory.getContainerProperties().setAckMode(ContainerProperties.AckMode.RECORD);
+        return factory;
+    }
+}

--- a/src/main/java/com/itmentorcommunityplatform/profileservice/consumer/AuthUserCreatedConsumer.java
+++ b/src/main/java/com/itmentorcommunityplatform/profileservice/consumer/AuthUserCreatedConsumer.java
@@ -1,0 +1,28 @@
+package com.itmentorcommunityplatform.profileservice.consumer;
+
+import com.itmentorcommunityplatform.profileservice.dto.event.UserCreatedEvent;
+import com.itmentorcommunityplatform.profileservice.service.ProfileService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class AuthUserCreatedConsumer {
+
+    private final ProfileService profileService;
+
+    @KafkaListener(topics = "auth.user.created", groupId = "profile-service-group")
+    public void consumeUserCreatedEvent(UserCreatedEvent event) {
+        log.info("Kafka Consumer: Received user created event: {}", event);
+        try {
+            profileService.createProfile(event);
+            log.info("Kafka Consumer: Successfully processed event for user {}", event.getTelegramUserId());
+        } catch (Exception e) {
+            log.error("Kafka Consumer: Error processing event for user {}", event.getTelegramUserId(), e);
+            throw e;
+        }
+    }
+}

--- a/src/main/java/com/itmentorcommunityplatform/profileservice/dto/event/UserCreatedEvent.java
+++ b/src/main/java/com/itmentorcommunityplatform/profileservice/dto/event/UserCreatedEvent.java
@@ -1,0 +1,17 @@
+package com.itmentorcommunityplatform.profileservice.dto.event;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class UserCreatedEvent {
+
+    @JsonProperty("telegram_user_id")
+    private Long telegramUserId;
+}

--- a/src/main/java/com/itmentorcommunityplatform/profileservice/service/ProfileService.java
+++ b/src/main/java/com/itmentorcommunityplatform/profileservice/service/ProfileService.java
@@ -6,6 +6,7 @@ import com.itmentorcommunityplatform.profileservice.domain.type.ProfileDetailTyp
 import com.itmentorcommunityplatform.profileservice.dto.ProfileDto;
 import com.itmentorcommunityplatform.profileservice.dto.request.ProfileUpdateRequestDto;
 import com.itmentorcommunityplatform.profileservice.dto.request.ProfileUpsertInternalRequestDto;
+import com.itmentorcommunityplatform.profileservice.dto.event.UserCreatedEvent;
 import com.itmentorcommunityplatform.profileservice.metrics.ProfileMetrics;
 import com.itmentorcommunityplatform.profileservice.repository.ProfileRepository;
 import com.itmentorcommunityplatform.profileservice.validator.base.BaseProfileDetailValidator;
@@ -19,6 +20,9 @@ import org.springframework.web.server.ResponseStatusException;
 
 import java.util.*;
 import java.util.stream.Collectors;
+import java.util.HashSet;
+import java.util.Optional;
+import java.util.Set;
 
 @Slf4j
 @Service
@@ -29,6 +33,29 @@ public class ProfileService {
     private final ProfileMetrics profileMetrics;
     private final BaseProfileDetailValidator baseDetailValidator;
     private final ProfileDetailValidatorRegistry detailValidatorRegistry;
+
+    @Transactional
+    public void createProfile(UserCreatedEvent event) {
+        if (event == null || event.getTelegramUserId() == null) {
+            log.warn("Received empty event or null telegramUserId. Skipping.");
+            return;
+        }
+        Long telegramUserId = event.getTelegramUserId();
+        log.info("Attempting to create profile for telegramUserId: {}", telegramUserId);
+
+        if (profileRepository.findByTelegramUserId(telegramUserId).isPresent()) {
+            log.info("Profile for telegramUserId: {} already exists. Skipping creation.", telegramUserId);
+            return;
+        }
+        Profile newProfile = Profile.builder()
+                .id(null)
+                .telegramUserId(telegramUserId)
+                .details(new HashSet<>())
+                .build();
+
+        profileRepository.save(newProfile);
+        log.info("Successfully created profile with telegramUserId: {}", telegramUserId);
+    }
 
     public ProfileDto getCurrentUserProfile(Long telegramUserId) {
         return profileMetrics.getGetProfileTimer().record(() -> {

--- a/src/main/resources/application-ide.yaml
+++ b/src/main/resources/application-ide.yaml
@@ -12,4 +12,4 @@ spring:
     driver-class-name: org.postgresql.Driver
 
   kafka:
-    bootstrap-servers: localhost:9092
+    bootstrap-servers: localhost:29092

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -10,6 +10,9 @@ spring:
 
   kafka:
     bootstrap-servers: ${KAFKA_BOOTSTRAP_SERVERS}
+    consumer:
+      group-id: profile-service-group
+      auto-offset-reset: earliest
 
   liquibase:
     change-log: classpath:db/changelog/db.changelog-master.yaml


### PR DESCRIPTION
- Настроена конфигурация Kafka с fail-fast поведением при невозможности подключиться
- Реализован consumer для топика auth.user.created
- Расширена логика ProfileService - профиль создаётся при получении события
- Обновлены настройки в application.yaml

Результат
При создании пользователя в Auth Service и публикации события в Kafka сервис Profile Service автоматически создаёт запись в таблице profiles.