### PR TITLE
Сохранение достижений

### DIFF
--- a/src/main/java/com/itmentorcommunityplatform/profileservice/consumer/ProjectCreatedConsumer.java
+++ b/src/main/java/com/itmentorcommunityplatform/profileservice/consumer/ProjectCreatedConsumer.java
@@ -1,16 +1,29 @@
 package com.itmentorcommunityplatform.profileservice.consumer;
 
+import com.itmentorcommunityplatform.profileservice.domain.type.AchievementType;
 import com.itmentorcommunityplatform.profileservice.dto.event.ProjectCreatedEvent;
+import com.itmentorcommunityplatform.profileservice.service.AchievementService;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.kafka.annotation.KafkaListener;
 import org.springframework.stereotype.Component;
 
 @Slf4j
 @Component
+@RequiredArgsConstructor
 public class ProjectCreatedConsumer {
 
+    private final AchievementService achievementService;
+
     @KafkaListener(topics = "projects.project.created", groupId = "profile-service-cg")
-    public void consumeProjectCreatedEvent(ProjectCreatedEvent projectCreatedEvent) {
-        log.info("Added new project: {}", projectCreatedEvent);
+    public void consumeProjectCreatedEvent(ProjectCreatedEvent event) {
+        log.info("Added new project: {}", event);
+        try {
+            achievementService.awardAchievement(event, AchievementType.TEST_ACHIEVEMENTS);
+            log.info("Kafka Consumer: Successfully processed event for user {}", event.getAuthorTelegramUserId());
+        } catch (Exception e) {
+            log.error("Kafka Consumer: Error processing event for user: {}. Error: {}",
+                    event.getAuthorTelegramUserId(), e.getMessage(), e);
+        }
     }
 }

--- a/src/main/java/com/itmentorcommunityplatform/profileservice/controller/InternalProfileController.java
+++ b/src/main/java/com/itmentorcommunityplatform/profileservice/controller/InternalProfileController.java
@@ -34,7 +34,5 @@ public class InternalProfileController {
 
         ProfileResponseDto profile = profileService.getProfileByGitHubUrl(gitHubUrl);
         return ResponseEntity.ok(profile);
-
-
     }
 }

--- a/src/main/java/com/itmentorcommunityplatform/profileservice/domain/Achievement.java
+++ b/src/main/java/com/itmentorcommunityplatform/profileservice/domain/Achievement.java
@@ -1,0 +1,30 @@
+package com.itmentorcommunityplatform.profileservice.domain;
+
+import com.itmentorcommunityplatform.profileservice.domain.type.AchievementType;
+import lombok.*;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.relational.core.mapping.Column;
+import org.springframework.data.relational.core.mapping.Table;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Table(name = "achievements")
+public class Achievement {
+
+    @Id
+    private Long id;
+
+    @Column("profile_id")
+    private Long profileId;
+
+    @Column("achievement_type")
+    private AchievementType achievementType;
+
+    @Column("earned_timestamp")
+    private Long earnedTimestamp;
+
+    @Column("publicly_visible")
+    private boolean publiclyVisible;
+}

--- a/src/main/java/com/itmentorcommunityplatform/profileservice/domain/type/AchievementType.java
+++ b/src/main/java/com/itmentorcommunityplatform/profileservice/domain/type/AchievementType.java
@@ -1,0 +1,5 @@
+package com.itmentorcommunityplatform.profileservice.domain.type;
+
+public enum AchievementType {
+    TEST_ACHIEVEMENTS
+}

--- a/src/main/java/com/itmentorcommunityplatform/profileservice/repository/AchievementRepository.java
+++ b/src/main/java/com/itmentorcommunityplatform/profileservice/repository/AchievementRepository.java
@@ -1,0 +1,19 @@
+package com.itmentorcommunityplatform.profileservice.repository;
+
+import com.itmentorcommunityplatform.profileservice.domain.Achievement;
+import com.itmentorcommunityplatform.profileservice.domain.type.AchievementType;
+import org.springframework.data.jdbc.repository.query.Query;
+import org.springframework.data.repository.CrudRepository;
+import org.springframework.data.repository.query.Param;
+
+public interface AchievementRepository extends CrudRepository<Achievement, Long> {
+
+    @Query("""
+            SELECT COUNT(*) > 0
+            FROM achievements
+            WHERE profile_id = :profileId AND achievement_type = :achievementType
+            """)
+    boolean existsByProfileIdAndAchievementType(@Param("profileId") Long profileId,
+                                                @Param("achievementType") AchievementType achievementType
+    );
+}

--- a/src/main/java/com/itmentorcommunityplatform/profileservice/service/AchievementService.java
+++ b/src/main/java/com/itmentorcommunityplatform/profileservice/service/AchievementService.java
@@ -1,0 +1,62 @@
+package com.itmentorcommunityplatform.profileservice.service;
+
+import com.itmentorcommunityplatform.profileservice.domain.Achievement;
+import com.itmentorcommunityplatform.profileservice.domain.Profile;
+import com.itmentorcommunityplatform.profileservice.domain.type.AchievementType;
+import com.itmentorcommunityplatform.profileservice.dto.event.ProjectCreatedEvent;
+import com.itmentorcommunityplatform.profileservice.repository.AchievementRepository;
+import com.itmentorcommunityplatform.profileservice.repository.ProfileRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class AchievementService {
+
+    private final AchievementRepository achievementRepository;
+    private final ProfileRepository profileRepository;
+
+    @Transactional
+    public void awardAchievement(ProjectCreatedEvent event, AchievementType achievementType) {
+        if (event == null || event.getAuthorTelegramUserId() == null) {
+            log.warn("Received empty event or null author ID");
+            return;
+        }
+
+        Long telegramUserId = event.getAuthorTelegramUserId();
+
+        Optional<Profile> maybeProfile = profileRepository.findByTelegramUserId(telegramUserId);
+
+        if (maybeProfile.isEmpty()) {
+            log.warn("Profile not found for telegramUserId {}. Skipping achievement.", telegramUserId);
+            return;
+        }
+
+        Profile profile = maybeProfile.get();
+
+        if (alreadyHasAchievement(profile.getId(), achievementType)) {
+            log.info("Achievement issuance skipped: user (profileId: {}({})) already owns achievement of type: {}",
+                    profile.getId(),event.getAuthorTelegramUserId(), achievementType);
+            return;
+        }
+
+        Achievement achievement = Achievement
+                .builder()
+                .profileId(profile.getId())
+                .achievementType(achievementType)
+                .earnedTimestamp(System.currentTimeMillis())
+                .publiclyVisible(true)
+                .build();
+
+        achievementRepository.save(achievement);
+    }
+
+    private boolean alreadyHasAchievement(Long profileId, AchievementType type) {
+        return achievementRepository.existsByProfileIdAndAchievementType(profileId, type);
+    }
+}

--- a/src/main/resources/db/changelog/changesets/002-create-table.sql
+++ b/src/main/resources/db/changelog/changesets/002-create-table.sql
@@ -1,0 +1,13 @@
+CREATE TABLE achievements (
+    id BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    profile_id BIGINT NOT NULL,
+    achievement_type VARCHAR(255) NOT NULL,
+    earned_timestamp BIGINT NOT NULL,
+    publicly_visible BOOLEAN NOT NULL,
+
+    CONSTRAINT fk_achievements_profile
+        FOREIGN KEY (profile_id) REFERENCES profiles(id)
+);
+
+CREATE UNIQUE INDEX idx_achievements_unique
+    ON achievements (profile_id, achievement_type);

--- a/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -1,3 +1,5 @@
 databaseChangeLog:
   - include:
       file: db/changelog/changesets/001-create-tables.sql
+  - include:
+      file: db/changelog/changesets/002-create-table.sql


### PR DESCRIPTION
- Написал миграцию согласно схеме. [Схема](https://github.com/it-mentor-community-platform/meta/blob/main/system-analytics/services/profile-service/index.md#%D1%81%D1%85%D0%B5%D0%BC%D0%B0-%D0%B1%D0%B4)

- Когда консьюмер читает из топика (projects.project.created), я вызываю свой сервис и на вход передаю ему сам event + тестовое достижение. (Пока что решил захардкодить, скорее всего, дальше будет сервис, который проверяет условия и будет передавать на вход достижение в мой сервис для дальнейшей записи в БД).

- В самом awardAchievement я решил не кидать исключения, а выводить лог и выходить из метода. Насколько я знаю, Kafka может бесконечно ретраить сообщение и зациклиться, для такого на сколько я знаю нужно создать DLQ-топик что бы там исключения складывать.

- Сам объект Achievement я собираю через паттерн билдер и по умолчанию ставлю publiclyVisible = true, так как в ТЗ не указан изначальный параметр для видимости достижений пользователя