### PR TITLE
Добавлен список достижений в эндпоинт получения профиля

### DIFF
--- a/src/main/java/com/itmentorcommunityplatform/profileservice/dto/ProfileAchievementsDto.java
+++ b/src/main/java/com/itmentorcommunityplatform/profileservice/dto/ProfileAchievementsDto.java
@@ -1,0 +1,16 @@
+package com.itmentorcommunityplatform.profileservice.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.itmentorcommunityplatform.profileservice.domain.type.AchievementType;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class ProfileAchievementsDto {
+
+    private final AchievementType type;
+
+    @JsonProperty("earned_timestamp")
+    private final Long earnedTimestamp;
+}

--- a/src/main/java/com/itmentorcommunityplatform/profileservice/dto/ProfileDetailsResponseDto.java
+++ b/src/main/java/com/itmentorcommunityplatform/profileservice/dto/ProfileDetailsResponseDto.java
@@ -19,14 +19,14 @@ import java.util.Map;
 )
 public class ProfileDetailsResponseDto {
 
-    private final Map<String, String> details;
+    private final Map<String, Object> details;
 
-    public ProfileDetailsResponseDto(Map<String, String> details) {
+    public ProfileDetailsResponseDto(Map<String, Object> details) {
         this.details = details;
     }
 
     @JsonAnyGetter
-    public Map<String, String> anyToJson() {
+    public Map<String, Object> anyToJson() {
         return details;
     }
 }

--- a/src/main/java/com/itmentorcommunityplatform/profileservice/repository/AchievementRepository.java
+++ b/src/main/java/com/itmentorcommunityplatform/profileservice/repository/AchievementRepository.java
@@ -4,7 +4,11 @@ import com.itmentorcommunityplatform.profileservice.domain.Achievement;
 import com.itmentorcommunityplatform.profileservice.domain.type.AchievementType;
 import org.springframework.data.repository.CrudRepository;
 
+import java.util.List;
+
 public interface AchievementRepository extends CrudRepository<Achievement, Long> {
 
     boolean existsByProfileIdAndAchievementType(Long profileId, AchievementType achievementType);
+
+    List<Achievement> findAllByProfileIdAndPubliclyVisibleTrue(Long profileId);
 }

--- a/src/main/java/com/itmentorcommunityplatform/profileservice/service/ProfileService.java
+++ b/src/main/java/com/itmentorcommunityplatform/profileservice/service/ProfileService.java
@@ -1,8 +1,10 @@
 package com.itmentorcommunityplatform.profileservice.service;
 
+import com.itmentorcommunityplatform.profileservice.domain.Achievement;
 import com.itmentorcommunityplatform.profileservice.domain.Profile;
 import com.itmentorcommunityplatform.profileservice.domain.ProfileDetail;
 import com.itmentorcommunityplatform.profileservice.domain.type.ProfileDetailType;
+import com.itmentorcommunityplatform.profileservice.dto.ProfileAchievementsDto;
 import com.itmentorcommunityplatform.profileservice.dto.ProfileDetailsResponseDto;
 import com.itmentorcommunityplatform.profileservice.dto.ProfileResponseDto;
 import com.itmentorcommunityplatform.profileservice.dto.event.ProjectCreatedEvent;
@@ -10,6 +12,7 @@ import com.itmentorcommunityplatform.profileservice.dto.event.UserCreatedEvent;
 import com.itmentorcommunityplatform.profileservice.dto.request.ProfileUpdateRequestDto;
 import com.itmentorcommunityplatform.profileservice.dto.request.ProfileUpsertInternalRequestDto;
 import com.itmentorcommunityplatform.profileservice.metrics.ProfileMetrics;
+import com.itmentorcommunityplatform.profileservice.repository.AchievementRepository;
 import com.itmentorcommunityplatform.profileservice.repository.ProfileRepository;
 import com.itmentorcommunityplatform.profileservice.validator.base.BaseProfileDetailValidator;
 import com.itmentorcommunityplatform.profileservice.validator.impl.GithubProfileUrlValidator;
@@ -30,6 +33,7 @@ import java.util.stream.Collectors;
 public class ProfileService {
 
     private final ProfileRepository profileRepository;
+    private final AchievementRepository achievementRepository;
     private final ProfileMetrics profileMetrics;
     private final BaseProfileDetailValidator baseDetailValidator;
     private final ProfileDetailValidatorRegistry detailValidatorRegistry;
@@ -64,8 +68,11 @@ public class ProfileService {
             try {
                 Profile profile = profileRepository.findByTelegramUserId(telegramUserId)
                         .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Profile not found"));
+
+                List<Achievement> achievements = achievementRepository.findAllByProfileIdAndPubliclyVisibleTrue(profile.getId());
+
                 profileMetrics.getGetProfileSuccessCounter().increment();
-                return mapToProfileDetailDto(profile.getDetails());
+                return mapToProfileDetailDto(profile.getDetails(), achievements);
             } catch (Exception e) {
                 profileMetrics.getGetProfileErrorCounter().increment();
                 throw e;
@@ -83,12 +90,14 @@ public class ProfileService {
                 Profile profile = profileRepository.findByTelegramUserId(telegramUserId)
                         .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Profile not found"));
 
+                List<Achievement> achievements = achievementRepository.findAllByProfileIdAndPubliclyVisibleTrue(profile.getId());
+
                 Set<ProfileDetail> mergedDetails = mergeProfileDetails(profile.getDetails(), newDetailsMap);
                 profile.setDetails(mergedDetails);
 
                 profileRepository.save(profile);
                 profileMetrics.getGetProfileSuccessCounter().increment();
-                return mapToProfileDetailDto(profile.getDetails());
+                return mapToProfileDetailDto(profile.getDetails(), achievements);
             } catch (Exception e) {
                 profileMetrics.getGetProfileErrorCounter().increment();
                 throw e;
@@ -96,9 +105,17 @@ public class ProfileService {
         });
     }
 
-    private ProfileDetailsResponseDto mapToProfileDetailDto(Set<ProfileDetail> details) {
-        Map<String, String> map = details.stream()
-                .collect(Collectors.toMap(ProfileDetail::getDetailName, ProfileDetail::getDetailValue));
+    private ProfileDetailsResponseDto mapToProfileDetailDto(Set<ProfileDetail> details, List<Achievement> achievements) {
+        List<ProfileAchievementsDto> profileAchievements = achievements.stream()
+                .map(achievement -> new ProfileAchievementsDto(achievement.getAchievementType(),
+                        achievement.getEarnedTimestamp()))
+                .collect(Collectors.toList());
+
+        LinkedHashMap<String, Object> map = new LinkedHashMap<>();
+
+        details.forEach(detail -> map.put(detail.getDetailName(), detail.getDetailValue()));
+
+        map.put("achievements", profileAchievements);
 
         return new ProfileDetailsResponseDto(map);
     }
@@ -185,8 +202,10 @@ public class ProfileService {
                         "Profile with URL: %s not found".formatted(gitHubUrl)
                 ));
 
+        List<Achievement> achievements = achievementRepository.findAllByProfileIdAndPubliclyVisibleTrue(profile.getId());
+
         return new ProfileResponseDto(profile.getTelegramUserId(),
-                mapToProfileDetailDto(profile.getDetails()));
+                mapToProfileDetailDto(profile.getDetails(), achievements));
     }
 
     @Transactional(readOnly = true)


### PR DESCRIPTION
Решил не обновлять сущность Profile и не добавлять туда связь:

@MappedCollection(idColumn = "profile_id")
@Builder.Default
private Set<Achievement> achievements = new HashSet<>();

При загрузке профиля подтягивались бы сразу все ачивки, а мне нужны не все, а только публичные

Сущность Profile оставил как есть

Добавил ProfileAchievementsDto с нужными полями для маппинга в JSON

В ProfileDetailsResponseDto изменил тип мапы со String, String на String, Object, чтобы туда можно было поместить список ачивок

В методе mapToProfileDetailDto я получаю на вход все ачивки, маплю их в нужные дто и помещаю в LinkedHashMap в нужном мне порядке

Изначально я пробовал просто добавить новое поле в ProfileDetailsResponseDto, но возникла проблема с порядком полей в JSON. Аннотация @JsonAnyGetter отрабатывает после сериализации основных полей класса, из за чего список ачивок всегда оказывался в самом начале ответа, а данные пользователя в конце. А LinkedHashMap позволяет гарантировать нужный мне порядок