### PR TITLE
Изменения деталей first_name и last_name на эндпоинте редактирования профиля

### DIFF
--- a/httpRequests/profile-update.http
+++ b/httpRequests/profile-update.http
@@ -2,11 +2,12 @@
 ###
 PATCH http://localhost:8083/api/profile
 Content-Type: application/json
-X-Telegram-User-Id: 10001
+X-Telegram-User-Id: 39671982
 
 {
-  "github_profile_url": "https://github.com/zhukovaasfssd",
-  "telegram_url": "https://t.me/zhokovsd"
+  "github_profile_url": "https://github.com/JollykaiTEST1",
+  "first_name": "Dmitry",
+  "last_name": "OxErr"
 }
 ###
 
@@ -41,6 +42,28 @@ X-Telegram-User-Id: 10001
 {
   "github_profile_url": "htt://github.com/zhukovaasfssd",
   "telegram_url": "https://t.me/zhokovsd"
+}
+###
+
+///403 - попытка изменить "telegram_url"
+###
+PATCH http://localhost:8083/api/profile
+Content-Type: application/json
+X-Telegram-User-Id: 39671982
+
+{
+  "telegram_url": "https://t.me/zhukovaasfssd"
+}
+###
+
+///404 - профиль текущего пользователя не существует
+###
+PATCH http://localhost:8083/api/profile
+Content-Type: application/json
+X-Telegram-User-Id: 1
+
+{
+  "telegram_url": "https://t.me/zhukovaasfssd"
 }
 ###
 

--- a/src/main/java/com/itmentorcommunityplatform/profileservice/docs/UpdateCurrentProfileDocs.java
+++ b/src/main/java/com/itmentorcommunityplatform/profileservice/docs/UpdateCurrentProfileDocs.java
@@ -28,9 +28,8 @@ import java.lang.annotation.Target;
                 ```json
                 {
                   "github_profile_url": "https://github.com/johndoe",
-                  "telegram_url": "https://t.me/johndoe",
-                  "first_name": "Arc",
-                  "last_name": "Warden"
+                  "first_name": "Dmitry",
+                  "last_name": "OxErr"
                 }
                 ```
                 """,
@@ -44,9 +43,8 @@ import java.lang.annotation.Target;
                                 value = """
                                         {
                                           "github_profile_url": "https://github.com/johndoe",
-                                          "telegram_url": "https://t.me/johndoe",
-                                          "first_name": "Arc",
-                                          "last_name": "Warden"
+                                          "first_name": "Dmitry",
+                                          "last_name": "OxErr"
                                         }
                                         """
                         )
@@ -56,15 +54,28 @@ import java.lang.annotation.Target;
 @ApiResponses({
         @ApiResponse(
                 responseCode = "200",
-                description = "Profile updated successfully",
+                description = "Profile updated successfully. Returns full profile state.",
                 content = @Content(schema = @Schema(implementation = ProfileDetailsResponseDto.class))
         ),
         @ApiResponse(
                 responseCode = "400",
-                description = "Invalid request",
-                content = @Content(schema = @Schema(
-                        example = "{\"message\":\"Bad request\"}"
-                ))
+                description = "Validation error (invalid fields, incorrect GitHub URL format, or empty body)",
+                content = @Content(schema = @Schema(example = "{\"message\":\"Invalid request or validation failed\"}"))
+        ),
+        @ApiResponse(
+                responseCode = "403",
+                description = "Attempt to modify protected field 'telegram_url'",
+                content = @Content(schema = @Schema(example = "{\"message\":\"Modifying 'telegram_url' is not allowed\"}"))
+        ),
+        @ApiResponse(
+                responseCode = "404",
+                description = "Profile for the current user does not exist",
+                content = @Content(schema = @Schema(example = "{\"message\":\"Profile not found\"}"))
+        ),
+        @ApiResponse(
+                responseCode = "500",
+                description = "Unknown internal server error",
+                content = @Content(schema = @Schema(example = "{\"message\":\"An unexpected error occurred\"}"))
         )
 })
 public @interface UpdateCurrentProfileDocs {

--- a/src/main/java/com/itmentorcommunityplatform/profileservice/dto/request/ProfileUpdateRequestDto.java
+++ b/src/main/java/com/itmentorcommunityplatform/profileservice/dto/request/ProfileUpdateRequestDto.java
@@ -13,7 +13,8 @@ import java.util.Map;
         example = """
         {
           "github_profile_url": "https://github.com/johndoe",
-          "telegram_url": "https://t.me/johndoe"
+          "first_name": "Dmitry",
+          "last_name": "OxErr"
         }
         """
 )

--- a/src/main/java/com/itmentorcommunityplatform/profileservice/service/ProfileService.java
+++ b/src/main/java/com/itmentorcommunityplatform/profileservice/service/ProfileService.java
@@ -102,6 +102,12 @@ public class ProfileService {
         return profileMetrics.getGetProfileTimer().record(() -> {
             try {
                 Map<String, String> newDetailsMap = dto.getDetails();
+
+                if (newDetailsMap.containsKey("telegram_url")) {
+                    log.error("Attempt to modify protected field 'telegram_url'");
+                    throw new ResponseStatusException(HttpStatus.FORBIDDEN, "Modifying 'telegram_url' is not allowed");
+                }
+
                 validateDetails(newDetailsMap);
 
                 Profile profile = profileRepository.findByTelegramUserId(telegramUserId)


### PR DESCRIPTION
- Редактировать новые поля и так можно было, там же любой JSON в мапу собирается `Map<String, String> details = new HashMap<>();` 
- по ТЗ почему то в апишке по обновление публичного профиля текущего пользователя не было проверки на `403 - попытка изменить "telegram_url"` хотя по [ТЗ](https://github.com/it-mentor-community-platform/meta/blob/main/system-analytics/services/profile-service/index.md#%D0%BE%D0%B1%D0%BD%D0%BE%D0%B2%D0%BB%D0%B5%D0%BD%D0%B8%D0%B5-%D0%BF%D1%83%D0%B1%D0%BB%D0%B8%D1%87%D0%BD%D0%BE%D0%B3%D0%BE-%D0%BF%D1%80%D0%BE%D1%84%D0%B8%D0%BB%D1%8F-%D1%82%D0%B5%D0%BA%D1%83%D1%89%D0%B5%D0%B3%D0%BE-%D0%BF%D0%BE%D0%BB%D1%8C%D0%B7%D0%BE%D0%B2%D0%B0%D1%82%D0%B5%D0%BB%D1%8F) должно быть. Так что добавил проверку.
- Обновил доку
- Обновил http тесты