### PR TITLE
Staging профиль (Profile service)

### DIFF
--- a/src/main/resources/application-local-stack.yaml
+++ b/src/main/resources/application-local-stack.yaml
@@ -11,4 +11,4 @@ spring:
 feign:
   client:
     auth-service:
-      url: http://localhost:8081/api/auth
+      url: http://auth-service:8080/api/auth

--- a/src/main/resources/application-staging.yml
+++ b/src/main/resources/application-staging.yml
@@ -1,0 +1,18 @@
+spring:
+  config:
+    activate:
+      on-profile: staging
+
+  datasource:
+    url: ${POSTGRES_URL}
+    username: ${POSTGRES_USERNAME}
+    password: ${POSTGRES_PASSWORD}
+    driver-class-name: org.postgresql.Driver
+
+  kafka:
+    bootstrap-servers: kafka:9092
+
+feign:
+  client:
+    auth-service:
+      url: ${AUTH_SERVICE_URL:http://auth-service:8080/api/auth}


### PR DESCRIPTION
- В `application-local-stack.yml` обращение к auth-service по имени сервиса и внутреннему порту контейнера 8080
- В `application-staging.yml` URL для auth-service можно задать через переменную окружения либо используется дефолтный адрес внутри k8s с портом 8080