### PR TITLE
Внутренний эндпоинт поиска профиля по ссылке на Telegram

### DIFF
--- a/httpRequests/internal-profile-search-github.http
+++ b/httpRequests/internal-profile-search-github.http
@@ -3,7 +3,6 @@ GET http://localhost:8083/api/profile/internal/profile/by-github-profile-url
     ?url=https://github.com/anelfer
 
 
-
 ### 2. Поиск профиля по невалидной ссылке(400 Bad request)
 GET http://localhost:8083/api/profile/internal/profile/by-github-profile-url
     ?url=https://invalidUrl.com/test
@@ -12,5 +11,3 @@ GET http://localhost:8083/api/profile/internal/profile/by-github-profile-url
 ### 3. Профиль не найден (404 Not found)
 GET http://localhost:8083/api/profile/internal/profile/by-github-profile-url
     ?url=https://github.com/unknown-github-profile
-
-###

--- a/httpRequests/internal-profile-search-telegram.http
+++ b/httpRequests/internal-profile-search-telegram.http
@@ -1,0 +1,13 @@
+### 1. Успешный поиск профиля по ссылке на тг (200 OK)
+GET http://localhost:8083/api/profile/internal/profile/by-telegram-url
+    ?url=https://t.me/LeslieFn
+
+
+### 2. Поиск профиля по невалидной ссылке(400 Bad request)
+GET http://localhost:8083/api/profile/internal/profile/by-telegram-url
+    ?url=https://invalidUrl.com/test
+
+
+### 3. Профиль не найден (404 Not found)
+GET http://localhost:8083/api/profile/internal/profile/by-telegram-url
+    ?url=https://t.me/demon

--- a/src/main/java/com/itmentorcommunityplatform/profileservice/controller/InternalProfileController.java
+++ b/src/main/java/com/itmentorcommunityplatform/profileservice/controller/InternalProfileController.java
@@ -1,6 +1,7 @@
 package com.itmentorcommunityplatform.profileservice.controller;
 
 import com.itmentorcommunityplatform.profileservice.docs.GetProfileByGithubUrlDocs;
+import com.itmentorcommunityplatform.profileservice.docs.GetProfileByTgUrlDocs;
 import com.itmentorcommunityplatform.profileservice.docs.UpsertInternalProfileDocs;
 import com.itmentorcommunityplatform.profileservice.dto.request.ProfileUpsertInternalRequestDto;
 import com.itmentorcommunityplatform.profileservice.dto.response.ProfileWithTelegramIdResponseDto;
@@ -33,6 +34,16 @@ public class InternalProfileController {
             @RequestParam("url") String gitHubUrl) {
 
         ProfileWithTelegramIdResponseDto profile = profileService.getProfileByGitHubUrl(gitHubUrl);
+        return ResponseEntity.ok(profile);
+    }
+
+    @GetMapping("/profile/by-telegram-url")
+    @GetProfileByTgUrlDocs
+    public ResponseEntity<ProfileWithTelegramIdResponseDto> getProfileByTgUrl(
+            @RequestParam("url") String tgUrl) {
+
+        ProfileWithTelegramIdResponseDto profile = profileService.getProfileByTgUrl(tgUrl);
+
         return ResponseEntity.ok(profile);
     }
 }

--- a/src/main/java/com/itmentorcommunityplatform/profileservice/docs/GetProfileByTgUrlDocs.java
+++ b/src/main/java/com/itmentorcommunityplatform/profileservice/docs/GetProfileByTgUrlDocs.java
@@ -1,0 +1,65 @@
+package com.itmentorcommunityplatform.profileservice.docs;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+@Operation(
+        summary = "Get profile by Telegram URL (internal)",
+        description = "Returns the user profile from a Telegram URL"
+)
+@ApiResponses({
+        @ApiResponse(
+                responseCode = "200",
+                description = "Profile received successfully",
+                content = @Content(
+                        mediaType = "application/json",
+                        schema = @Schema(example = """
+                                        {
+                                          "telegram_user_id": 12345,
+                                          "details": {
+                                            "github_profile_url": "https://github.com/zhukov",
+                                            "telegram_url": "https://t.me/zhukov",
+                                            "first_name": "Sergey",
+                                            "last_name": "Zhukov"
+                                          }
+                                        }
+                                """)
+                )
+        ),
+        @ApiResponse(
+                responseCode = "400",
+                description = "Validation error (invalid Telegram URL)",
+                content = @Content(
+                        mediaType = "application/json",
+                        schema = @Schema(example = """
+                                        {
+                                          "message": "Telegram profile url incorrect"
+                                        }
+                                """)
+                )
+        ),
+        @ApiResponse(
+                responseCode = "404",
+                description = "Profile not found",
+                content = @Content(
+                        mediaType = "application/json",
+                        schema = @Schema(example = """
+                                        {
+                                          "message": "Profile with given Telegram URL not found"
+                                        }
+                                """)
+                )
+        )
+})
+public @interface GetProfileByTgUrlDocs {
+}

--- a/src/main/java/com/itmentorcommunityplatform/profileservice/repository/ProfileRepository.java
+++ b/src/main/java/com/itmentorcommunityplatform/profileservice/repository/ProfileRepository.java
@@ -20,6 +20,13 @@ public interface ProfileRepository extends CrudRepository<Profile, Long> {
             WHERE pd.detail_name = 'github_profile_url' AND pd.detail_value = :gitHubUrl""")
     Optional<Profile> findProfileByGitHubUrl(@Param("gitHubUrl") String gitHubUrl);
 
+    @Query("""
+        SELECT p.*
+        FROM profiles p
+        JOIN profiles_details pd ON p.id = pd.profile_id
+        WHERE pd.detail_name = 'telegram_url' AND pd.detail_value = :tgUrl""")
+    Optional<Profile> findProfileByTgUrl(@Param("tgUrl") String tgUrl);
+
 
     @Query("""
                 SELECT p.*

--- a/src/main/java/com/itmentorcommunityplatform/profileservice/service/ProfileService.java
+++ b/src/main/java/com/itmentorcommunityplatform/profileservice/service/ProfileService.java
@@ -18,6 +18,7 @@ import com.itmentorcommunityplatform.profileservice.repository.AchievementReposi
 import com.itmentorcommunityplatform.profileservice.repository.ProfileRepository;
 import com.itmentorcommunityplatform.profileservice.validator.base.BaseProfileDetailValidator;
 import com.itmentorcommunityplatform.profileservice.validator.impl.GithubProfileUrlValidator;
+import com.itmentorcommunityplatform.profileservice.validator.impl.TelegramProfileUrlValidator;
 import com.itmentorcommunityplatform.profileservice.validator.registry.ProfileDetailValidatorRegistry;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -42,6 +43,7 @@ public class ProfileService {
     private final GithubProfileUrlValidator githubProfileUrlValidator;
     private final ProfileMapper profileMapper;
     private final AuthServiceClient authServiceClient;
+    private final TelegramProfileUrlValidator telegramProfileUrlValidator;
 
 
     @Transactional
@@ -280,6 +282,19 @@ public class ProfileService {
         }
 
         return new AllProfilesPaginatedResponseDto(allProfilesCount, totalPageCount, allProfilesPaginated.size(), pageNumber, items);
+    }
+
+    public ProfileWithTelegramIdResponseDto getProfileByTgUrl(String tgUrl) {
+
+        telegramProfileUrlValidator.validate(tgUrl);
+
+        log.info("Searching profile by Telegram URL: {}", tgUrl);
+
+        Profile profile = profileRepository.findProfileByTgUrl(tgUrl).orElseThrow(
+                () -> new ResponseStatusException(HttpStatus.NOT_FOUND,
+                        "Profile with given Telegram URL not found"));
+
+        return profileMapper.mapToProfileWithTelegramIdDto(profile.getTelegramUserId(), profile.getDetails());
     }
 
     private List<ProfileWithRolesResponseDto> enrichProfilesWithRoles(List<Profile> profiles) {

--- a/src/main/java/com/itmentorcommunityplatform/profileservice/validator/impl/TelegramProfileUrlValidator.java
+++ b/src/main/java/com/itmentorcommunityplatform/profileservice/validator/impl/TelegramProfileUrlValidator.java
@@ -1,0 +1,29 @@
+package com.itmentorcommunityplatform.profileservice.validator.impl;
+
+import com.itmentorcommunityplatform.profileservice.domain.type.ProfileDetailType;
+import com.itmentorcommunityplatform.profileservice.validator.ProfileDetailValidator;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Component;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.util.regex.Pattern;
+
+import static com.itmentorcommunityplatform.profileservice.domain.type.ProfileDetailType.*;
+
+@Component
+public class TelegramProfileUrlValidator implements ProfileDetailValidator {
+
+    private static final Pattern TELEGRAM_PATTERN = Pattern.compile("^https://(t\\.me|telegram\\.me)/[a-zA-Z0-9_]{5,32}$");
+
+    @Override
+    public ProfileDetailType getSupportedProfileDetailType() {
+        return TELEGRAM_URL;
+    }
+
+    @Override
+    public void validate(String value) {
+        if (value == null || !TELEGRAM_PATTERN.matcher(value).matches()) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Telegram profile url incorrect");
+        }
+    }
+}


### PR DESCRIPTION
- Новый эндпоинт GET /api/profile/internal/profile/by-telegram-url?url=${:url}
     - URL телеграмма проходит валидацию
- Ручные .http тесты для успешного и всех не успешных сценариев
- Swagger документация